### PR TITLE
[V2.0.23] Disable worker inlining - specific version for chrome extension

### DIFF
--- a/packages/all/CHANGELOG.md
+++ b/packages/all/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @rrweb/all
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb-packer@2.0.23
+  - @saola.ai/rrweb@2.0.23
+  - @saola.ai/rrweb-types@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-all",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "publishConfig": {
     "access": "public"
   },
@@ -56,9 +56,9 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@saola.ai/rrweb-types": "^2.0.22",
-    "@saola.ai/rrweb-packer": "^2.0.22",
-    "@saola.ai/rrweb": "^2.0.22"
+    "@saola.ai/rrweb-types": "^2.0.23",
+    "@saola.ai/rrweb-packer": "^2.0.23",
+    "@saola.ai/rrweb": "^2.0.23"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/packer/CHANGELOG.md
+++ b/packages/packer/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @rrweb/packer
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb-types@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/packer/package.json
+++ b/packages/packer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-packer",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "publishConfig": {
     "access": "public"
   },
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "fflate": "^0.4.4",
-    "@saola.ai/rrweb-types": "^2.0.22"
+    "@saola.ai/rrweb-types": "^2.0.23"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @rrweb/rrweb-plugin-canvas-webrtc-record
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-plugin-canvas-webrtc-record",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-canvas-webrtc-record.umd.cjs",
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@saola.ai/rrweb": "^2.0.22",
+    "@saola.ai/rrweb": "^2.0.23",
     "typescript": "^5.4.5",
     "vite": "^6.0.1",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@saola.ai/rrweb": "^2.0.22"
+    "@saola.ai/rrweb": "^2.0.23"
   }
 }

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @rrweb/rrweb-plugin-canvas-webrtc-replay
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-plugin-canvas-webrtc-replay",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-canvas-webrtc-replay.umd.cjs",
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@saola.ai/rrweb": "^2.0.22",
+    "@saola.ai/rrweb": "^2.0.23",
     "typescript": "^5.4.5",
     "vite": "^6.0.1",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@saola.ai/rrweb": "^2.0.22"
+    "@saola.ai/rrweb": "^2.0.23"
   }
 }

--- a/packages/plugins/rrweb-plugin-console-record/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-console-record/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @rrweb/rrweb-plugin-console-record
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb@2.0.23
+  - @saola.ai/rrweb-utils@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/plugins/rrweb-plugin-console-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-plugin-console-record",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-console-record.umd.cjs",
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@saola.ai/rrweb": "^2.0.22",
+    "@saola.ai/rrweb": "^2.0.23",
     "typescript": "^5.4.5",
     "vite": "^6.0.1",
     "vite-plugin-dts": "^3.9.1",
@@ -53,7 +53,7 @@
     "puppeteer": "^20.9.0"
   },
   "peerDependencies": {
-    "@saola.ai/rrweb": "^2.0.22",
-    "@saola.ai/rrweb-utils": "^2.0.22"
+    "@saola.ai/rrweb": "^2.0.23",
+    "@saola.ai/rrweb-utils": "^2.0.23"
   }
 }

--- a/packages/plugins/rrweb-plugin-console-replay/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-console-replay/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @rrweb/rrweb-plugin-console-replay
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/plugins/rrweb-plugin-console-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-plugin-console-replay",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-console-replay.umd.cjs",
@@ -43,13 +43,13 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@saola.ai/rrweb-plugin-console-record": "^2.0.22",
-    "@saola.ai/rrweb": "^2.0.22",
+    "@saola.ai/rrweb-plugin-console-record": "^2.0.23",
+    "@saola.ai/rrweb": "^2.0.23",
     "typescript": "^5.4.5",
     "vite": "^6.0.1",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@saola.ai/rrweb": "^2.0.22"
+    "@saola.ai/rrweb": "^2.0.23"
   }
 }

--- a/packages/plugins/rrweb-plugin-sequential-id-record/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @rrweb/rrweb-plugin-sequential-id-record
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-plugin-sequential-id-record",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-sequential-id-record.umd.cjs",
@@ -43,12 +43,12 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@saola.ai/rrweb": "^2.0.22",
+    "@saola.ai/rrweb": "^2.0.23",
     "typescript": "^5.4.5",
     "vite": "^6.0.1",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@saola.ai/rrweb": "^2.0.22"
+    "@saola.ai/rrweb": "^2.0.23"
   }
 }

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/CHANGELOG.md
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @rrweb/rrweb-plugin-sequential-id-replay
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-plugin-sequential-id-replay",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "",
   "type": "module",
   "main": "./dist/rrweb-plugin-sequential-id-replay.umd.cjs",
@@ -43,13 +43,13 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@saola.ai/rrweb-plugin-sequential-id-record": "^2.0.22",
-    "@saola.ai/rrweb": "^2.0.22",
+    "@saola.ai/rrweb-plugin-sequential-id-record": "^2.0.23",
+    "@saola.ai/rrweb": "^2.0.23",
     "typescript": "^5.4.5",
     "vite": "^6.0.1",
     "vite-plugin-dts": "^3.9.1"
   },
   "peerDependencies": {
-    "@saola.ai/rrweb": "^2.0.22"
+    "@saola.ai/rrweb": "^2.0.23"
   }
 }

--- a/packages/record/CHANGELOG.md
+++ b/packages/record/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @rrweb/record
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb@2.0.23
+  - @saola.ai/rrweb-types@2.0.23
+  - @saola.ai/rrweb-utils@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/record",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "publishConfig": {
     "access": "public"
   },
@@ -55,9 +55,9 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@saola.ai/rrweb-types": "^2.0.22",
-    "@saola.ai/rrweb": "^2.0.22",
-    "@saola.ai/rrweb-utils": "^2.0.22"
+    "@saola.ai/rrweb-types": "^2.0.23",
+    "@saola.ai/rrweb": "^2.0.23",
+    "@saola.ai/rrweb-utils": "^2.0.23"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/replay/CHANGELOG.md
+++ b/packages/replay/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @rrweb/replay
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb@2.0.23
+  - @saola.ai/rrweb-types@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/replay",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "publishConfig": {
     "access": "public"
   },
@@ -56,8 +56,8 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@saola.ai/rrweb-types": "^2.0.22",
-    "@saola.ai/rrweb": "^2.0.22"
+    "@saola.ai/rrweb-types": "^2.0.23",
+    "@saola.ai/rrweb": "^2.0.23"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/rrdom-nodejs/CHANGELOG.md
+++ b/packages/rrdom-nodejs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # rrdom-nodejs
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrdom@2.0.23
+  - @saola.ai/rrweb-snapshot@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrdom-nodejs",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "scripts": {
     "dev": "vite build --watch",
     "build": "yarn turbo run prepublish",
@@ -55,7 +55,7 @@
     "cssom": "^0.5.0",
     "cssstyle": "^2.3.0",
     "nwsapi": "2.2.0",
-    "@saola.ai/rrdom": "^2.0.22",
-    "@saola.ai/rrweb-snapshot": "^2.0.22"
+    "@saola.ai/rrdom": "^2.0.23",
+    "@saola.ai/rrweb-snapshot": "^2.0.23"
   }
 }

--- a/packages/rrdom/CHANGELOG.md
+++ b/packages/rrdom/CHANGELOG.md
@@ -1,5 +1,14 @@
 # rrdom
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb-snapshot@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrdom",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "homepage": "https://github.com/rrweb-io/rrweb/tree/main/packages/rrdom#readme",
   "license": "MIT",
   "type": "module",
@@ -41,7 +41,7 @@
     "url": "https://github.com/rrweb-io/rrweb/issues"
   },
   "devDependencies": {
-    "@saola.ai/rrweb-types": "^2.0.22",
+    "@saola.ai/rrweb-types": "^2.0.23",
     "@types/puppeteer": "^5.4.4",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
@@ -52,6 +52,6 @@
     "vite-plugin-dts": "^3.9.1"
   },
   "dependencies": {
-    "@saola.ai/rrweb-snapshot": "^2.0.22"
+    "@saola.ai/rrweb-snapshot": "^2.0.23"
   }
 }

--- a/packages/rrvideo/CHANGELOG.md
+++ b/packages/rrvideo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # rrvideo
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb-player@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/rrvideo/package.json
+++ b/packages/rrvideo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrvideo",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "transform rrweb session into video",
   "main": "build/index.js",
   "bin": {
@@ -27,13 +27,13 @@
     "@types/node": "^18.15.11",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.3",
-    "@saola.ai/rrweb-types": "^2.0.22"
+    "@saola.ai/rrweb-types": "^2.0.23"
   },
   "dependencies": {
     "@open-tech-world/cli-progress-bar": "^2.0.2",
     "fs-extra": "^11.1.1",
     "minimist": "^1.2.5",
     "playwright": "^1.32.1",
-    "@saola.ai/rrweb-player": "^2.0.22"
+    "@saola.ai/rrweb-player": "^2.0.23"
   }
 }

--- a/packages/rrweb-player/CHANGELOG.md
+++ b/packages/rrweb-player/CHANGELOG.md
@@ -1,5 +1,15 @@
 # rrweb-player
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrweb-packer@2.0.23
+  - @saola.ai/replay@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@saola.ai/rrweb-player",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "devDependencies": {
-    "@saola.ai/rrweb-types": "^2.0.22",
+    "@saola.ai/rrweb-types": "^2.0.23",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/package": "^2.0.0",
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@tsconfig/svelte": "^1.0.0",
-    "@saola.ai/replay": "^2.0.22",
-    "@saola.ai/rrweb-packer": "^2.0.22"
+    "@saola.ai/replay": "^2.0.23",
+    "@saola.ai/rrweb-packer": "^2.0.23"
   },
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/rrweb-snapshot/CHANGELOG.md
+++ b/packages/rrweb-snapshot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rrweb-snapshot
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-snapshot",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
     "prepare": "npm run prepack",
@@ -54,8 +54,8 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb/tree/master/packages/rrweb-snapshot#readme",
   "devDependencies": {
-    "@saola.ai/rrweb-types": "^2.0.22",
-    "@saola.ai/rrweb-utils": "^2.0.22",
+    "@saola.ai/rrweb-types": "^2.0.23",
+    "@saola.ai/rrweb-utils": "^2.0.23",
     "@types/jsdom": "^20.0.0",
     "@types/node": "^18.15.11",
     "@types/puppeteer": "^5.4.4",

--- a/packages/rrweb/CHANGELOG.md
+++ b/packages/rrweb/CHANGELOG.md
@@ -1,5 +1,17 @@
 # rrweb
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
+- Updated dependencies []:
+  - @saola.ai/rrdom@2.0.23
+  - @saola.ai/rrweb-snapshot@2.0.23
+  - @saola.ai/rrweb-types@2.0.23
+  - @saola.ai/rrweb-utils@2.0.23
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",
@@ -84,13 +84,13 @@
     "vite-plugin-dts": "^3.9.1"
   },
   "dependencies": {
-    "@saola.ai/rrweb-types": "^2.0.22",
-    "@saola.ai/rrweb-utils": "^2.0.22",
+    "@saola.ai/rrweb-types": "^2.0.23",
+    "@saola.ai/rrweb-utils": "^2.0.23",
     "@types/css-font-loading-module": "0.0.7",
     "@xstate/fsm": "^1.4.0",
     "base64-arraybuffer": "^1.0.1",
     "mitt": "^3.0.0",
-    "@saola.ai/rrdom": "^2.0.22",
-    "@saola.ai/rrweb-snapshot": "^2.0.22"
+    "@saola.ai/rrdom": "^2.0.23",
+    "@saola.ai/rrweb-snapshot": "^2.0.23"
   }
 }

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rrweb/types
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-types",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rrweb/utils
 
+## 2.0.23
+
+### Patch Changes
+
+- Disable worker inlining - specific version for chrome extension
+
 ## 2.0.22
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saola.ai/rrweb-utils",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "publishConfig": {
     "access": "public"
   },

--- a/vite.config.default.ts
+++ b/vite.config.default.ts
@@ -14,7 +14,7 @@ const emptyOutDir = !process.argv.includes('--watch');
  * Chrome web store does not allow base64 inline workers.
  * For chrome extension, we need to disable worker inlining to pass the review.
  */
-const disableWorkerInlining = process.env.DISABLE_WORKER_INLINING === 'true';
+const disableWorkerInlining = true; // process.env.DISABLE_WORKER_INLINING === 'true';
 
 function minifyAndUMDPlugin({
   name,


### PR DESCRIPTION
each Saola rrweb version would be built twice - even numbers (v2.0.22) with worker inlining, odd (v2.0.23) without - just for the extension 